### PR TITLE
This commit removes redirection of stderr of executed commands to stdout

### DIFF
--- a/src/cli/cmd_manager.py
+++ b/src/cli/cmd_manager.py
@@ -1,4 +1,4 @@
-from subprocess import STDOUT, check_output, TimeoutExpired, CalledProcessError
+from subprocess import check_output, TimeoutExpired, CalledProcessError
 
 from log_config import main_logger
 from util.client_utils import clear_terminal_chars
@@ -26,7 +26,7 @@ class CommandManager:
             logger.debug("--> Verbose : Command is |{}|".format(cmd))
 
         try:
-            output = check_output(cmd, shell=True, stderr=STDOUT, timeout=timeout, encoding='utf8')
+            output = check_output(cmd, shell=True, timeout=timeout, encoding='utf8')
         except TimeoutExpired as e:
             raise e
         except CalledProcessError as e:


### PR DESCRIPTION
This causes a bug in DRD after recent modifications in dune-client.
For instance, a warning (syntax warning: for bar) has been added to
dune-client's stderr. This caused a parsing issue in DRD when retrieving
the list of known contracts and trying to parse it because of the
expected pattern <alias>: <pkh>.

But bug is simply fixed by ignoring stderr (which should always be done)

fixes https://github.com/habanoz/dune-reward-distributor/issues/8