### PR TITLE
use syntax 'dune-client -A addr -P port' when option -A is given to DRD

### DIFF
--- a/src/cli/simple_client_manager.py
+++ b/src/cli/simple_client_manager.py
@@ -1,5 +1,6 @@
 from cli.cmd_manager import CommandManager
 from exception.client import ClientException
+from util.client_utils import get_node_rpc_addr
 
 
 class SimpleClientManager:
@@ -10,8 +11,8 @@ class SimpleClientManager:
         self.cmd_manager = CommandManager(verbose)
 
     def send_request(self, cmd, verbose_override=None, timeout=None):
-        whole_cmd = self.client_path + cmd
-
+        rpc_addr = get_node_rpc_addr ()
+        whole_cmd = self.client_path + rpc_addr + cmd
         return self.cmd_manager.execute(whole_cmd, verbose_override, timeout=timeout)
 
     def sign(self, bytes, key_name, verbose_override=None):

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from util.client_utils import get_client_path
 from util.dir_utils import get_payment_root, \
     get_calculations_root, get_successful_payments_dir, get_failed_payments_dir
 from util.process_life_cycle import ProcessLifeCycle
+from util.client_utils import init_node_rpc_addr
 
 LINER = "--------------------------------------------"
 
@@ -80,6 +81,7 @@ def main(args):
 
     # 4. get network config
     config_client_manager = SimpleClientManager(client_path)
+    init_node_rpc_addr (args.node_addr);
     network_config_map = init_network_config(args.network, config_client_manager, args.node_addr)
     network_config = network_config_map[args.network]
 

--- a/src/util/client_utils.py
+++ b/src/util/client_utils.py
@@ -6,8 +6,23 @@ from log_config import main_logger
 DOCKER_CLIENT_EXE = "%network%.sh"
 DOCKER_CLIENT_EXE_SUFFIX = " client"
 REGULAR_CLIENT_EXE = "dune-client"
+DEFAULT_NODE_RPC_ADDR = ""
+DEFAULT_NODE_RPC_PORT = ""
 
 logger = main_logger
+
+def init_node_rpc_addr (node_addr):
+    global DEFAULT_NODE_RPC_ADDR
+    global DEFAULT_NODE_RPC_PORT
+    if node_addr != "":
+        addr, port = node_addr.split(":", maxsplit=1)
+        DEFAULT_NODE_RPC_ADDR = addr
+        DEFAULT_NODE_RPC_PORT = port
+
+def get_node_rpc_addr ():
+    if (DEFAULT_NODE_RPC_ADDR != ""):
+        return (" -A " + DEFAULT_NODE_RPC_ADDR + " -P " + DEFAULT_NODE_RPC_PORT + " ")
+    return ""
 
 def get_client_path(search_paths, docker=None, network_name=None, verbose=None):
     client_exe = REGULAR_CLIENT_EXE


### PR DESCRIPTION
Currently, commands are always ran with 'dune-client <rest of the cmd>.
Internally, this means that 'dune-client' will use the default addr/port
for its requests (for instance: localhost:8733 for mainnet). But some
people use different ports and may want to use a remote/public node.

This PR saves the node rpc addr/port provided by DRD option '-A'
(if option is set) in two new global variables 'DEFAULT_NODE_RPC_ADDR'
and 'DEFAULT_NODE_RPC_PORT' in 'client_utils.py', and apends the
'-A addr -P port' arguments to every 'dune-client' invocation

fixes https://github.com/habanoz/dune-reward-distributor/issues/10